### PR TITLE
py.sdk.todos(ci): add todos to samples workflow

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -24,6 +24,7 @@ jobs:
           - app: js.bolt.surge
           - app: js.bolt.tails
           - app: py.bolt.snaek
+          - app: py.sdk.todos
     steps:
       - name: Checkout this repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -102,6 +103,10 @@ jobs:
             deploy: |
               slack deploy --app $SLACK_APP_ID --token $SLACK_CLI_TOKEN --force
             test: make test
+          - app: py.sdk.todos
+            deploy: |
+              slack deploy --app $SLACK_APP_ID --token $SLACK_CLI_TOKEN --force
+            test: ruff check src/
     environment: ${{ matrix.app }}
     defaults:
       run:

--- a/py.sdk.todos/CHANGELOG.md
+++ b/py.sdk.todos/CHANGELOG.md
@@ -7,7 +7,14 @@ versioned with [semantic versioning][semver].
 
 ## Unreleased
 
+### Enhancements
+
 - feat: package scripts as commands to view and update tasks in lists
+
+### Maintenance
+
+- ci: run tests and republish changes after merges of feature branches
+- ci: add todos to the samples workflow for test and deploys
 
 [semver]: https://semver.org
 [commits]: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary

- Add todos to the synchronize job matrix for downstream mirroring
- Add todos to the publish job with test and deploy steps

:checkered_flag:

🤖 Generated with [Claude Code](https://claude.com/claude-code)