### PR TITLE
py.sdk.todos(fix): provide python with todos package for server

### DIFF
--- a/py.sdk.todos/flake.nix
+++ b/py.sdk.todos/flake.nix
@@ -80,7 +80,7 @@
           server = pkgs.writeShellApplication {
             name = "server";
             runtimeInputs = [
-              todos
+              (pkgs.python3.withPackages (_: [ todos ]))
             ];
             text = "python -m web.server \"$@\"";
           };


### PR DESCRIPTION
:dodo:

Fixes `nix run .#server` to work with `python -m web.server` by providing Python with the todos package in its path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)