### PR TITLE
chore(deps): bump slack-cli from 3.12.0 to 4.0.1

### DIFF
--- a/deno.sdk.begut/flake.nix
+++ b/deno.sdk.begut/flake.nix
@@ -25,13 +25,13 @@
             src =
               if pkgs.stdenv.isDarwin then
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_macOS_64-bit.tar.gz";
-                  hash = "sha256-reQ2cB/BeFqXxbF3JYBzI3nwO+Jk1KgjuMjCm3qgNX0=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_macOS_64-bit.tar.gz";
+                  hash = "sha256-oY7tZ/daAz58FsX5ZtV35eogr4oWxsqexrGPFTLXeB4=";
                 }
               else
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_linux_64-bit.tar.gz";
-                  hash = "sha256-A0QELxVKAZgPgjopWCleQFVzv2mBM3L57zZLMga0yHg=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_linux_64-bit.tar.gz";
+                  hash = "sha256-0CmqEF3sO+IOl4cLulU3vF5nxPv5z9EjAdf7kGOnqf4=";
                 };
             unpackPhase = "tar -xzf $src";
             installPhase = ''

--- a/deno.sdk.chanl/flake.nix
+++ b/deno.sdk.chanl/flake.nix
@@ -25,13 +25,13 @@
             src =
               if pkgs.stdenv.isDarwin then
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_macOS_64-bit.tar.gz";
-                  hash = "sha256-reQ2cB/BeFqXxbF3JYBzI3nwO+Jk1KgjuMjCm3qgNX0=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_macOS_64-bit.tar.gz";
+                  hash = "sha256-oY7tZ/daAz58FsX5ZtV35eogr4oWxsqexrGPFTLXeB4=";
                 }
               else
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_linux_64-bit.tar.gz";
-                  hash = "sha256-A0QELxVKAZgPgjopWCleQFVzv2mBM3L57zZLMga0yHg=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_linux_64-bit.tar.gz";
+                  hash = "sha256-0CmqEF3sO+IOl4cLulU3vF5nxPv5z9EjAdf7kGOnqf4=";
                 };
             unpackPhase = "tar -xzf $src";
             installPhase = ''

--- a/java.sdk.gibra/flake.nix
+++ b/java.sdk.gibra/flake.nix
@@ -25,13 +25,13 @@
             src =
               if pkgs.stdenv.isDarwin then
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_macOS_64-bit.tar.gz";
-                  hash = "sha256-reQ2cB/BeFqXxbF3JYBzI3nwO+Jk1KgjuMjCm3qgNX0=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_macOS_64-bit.tar.gz";
+                  hash = "sha256-oY7tZ/daAz58FsX5ZtV35eogr4oWxsqexrGPFTLXeB4=";
                 }
               else
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_linux_64-bit.tar.gz";
-                  hash = "sha256-A0QELxVKAZgPgjopWCleQFVzv2mBM3L57zZLMga0yHg=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_linux_64-bit.tar.gz";
+                  hash = "sha256-0CmqEF3sO+IOl4cLulU3vF5nxPv5z9EjAdf7kGOnqf4=";
                 };
             unpackPhase = "tar -xzf $src";
             installPhase = ''

--- a/js.bolt.surge/flake.nix
+++ b/js.bolt.surge/flake.nix
@@ -30,13 +30,13 @@
             src =
               if pkgs.stdenv.isDarwin then
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_macOS_64-bit.tar.gz";
-                  hash = "sha256-reQ2cB/BeFqXxbF3JYBzI3nwO+Jk1KgjuMjCm3qgNX0=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_macOS_64-bit.tar.gz";
+                  hash = "sha256-oY7tZ/daAz58FsX5ZtV35eogr4oWxsqexrGPFTLXeB4=";
                 }
               else
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_linux_64-bit.tar.gz";
-                  hash = "sha256-A0QELxVKAZgPgjopWCleQFVzv2mBM3L57zZLMga0yHg=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_linux_64-bit.tar.gz";
+                  hash = "sha256-0CmqEF3sO+IOl4cLulU3vF5nxPv5z9EjAdf7kGOnqf4=";
                 };
             unpackPhase = "tar -xzf $src";
             installPhase = ''

--- a/js.bolt.tails/flake.nix
+++ b/js.bolt.tails/flake.nix
@@ -46,13 +46,13 @@
             src =
               if pkgs.stdenv.isDarwin then
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_macOS_64-bit.tar.gz";
-                  hash = "sha256-reQ2cB/BeFqXxbF3JYBzI3nwO+Jk1KgjuMjCm3qgNX0=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_macOS_64-bit.tar.gz";
+                  hash = "sha256-oY7tZ/daAz58FsX5ZtV35eogr4oWxsqexrGPFTLXeB4=";
                 }
               else
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_linux_64-bit.tar.gz";
-                  hash = "sha256-A0QELxVKAZgPgjopWCleQFVzv2mBM3L57zZLMga0yHg=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_linux_64-bit.tar.gz";
+                  hash = "sha256-0CmqEF3sO+IOl4cLulU3vF5nxPv5z9EjAdf7kGOnqf4=";
                 };
             unpackPhase = "tar -xzf $src";
             installPhase = ''

--- a/py.bolt.snaek/flake.nix
+++ b/py.bolt.snaek/flake.nix
@@ -103,13 +103,13 @@
             src =
               if pkgs.stdenv.isDarwin then
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_macOS_64-bit.tar.gz";
-                  hash = "sha256-reQ2cB/BeFqXxbF3JYBzI3nwO+Jk1KgjuMjCm3qgNX0=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_macOS_64-bit.tar.gz";
+                  hash = "sha256-oY7tZ/daAz58FsX5ZtV35eogr4oWxsqexrGPFTLXeB4=";
                 }
               else
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_linux_64-bit.tar.gz";
-                  hash = "sha256-A0QELxVKAZgPgjopWCleQFVzv2mBM3L57zZLMga0yHg=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_linux_64-bit.tar.gz";
+                  hash = "sha256-0CmqEF3sO+IOl4cLulU3vF5nxPv5z9EjAdf7kGOnqf4=";
                 };
             unpackPhase = "tar -xzf $src";
             installPhase = ''

--- a/py.sdk.todos/flake.nix
+++ b/py.sdk.todos/flake.nix
@@ -25,13 +25,13 @@
             src =
               if pkgs.stdenv.isDarwin then
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_macOS_64-bit.tar.gz";
-                  sha256 = "sha256-reQ2cB/BeFqXxbF3JYBzI3nwO+Jk1KgjuMjCm3qgNX0=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_macOS_64-bit.tar.gz";
+                  sha256 = "sha256-oY7tZ/daAz58FsX5ZtV35eogr4oWxsqexrGPFTLXeB4=";
                 }
               else
                 pkgs.fetchurl {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.12.0_linux_64-bit.tar.gz";
-                  sha256 = "sha256-A0QELxVKAZgPgjopWCleQFVzv2mBM3L57zZLMga0yHg=";
+                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_4.0.1_linux_64-bit.tar.gz";
+                  sha256 = "sha256-0CmqEF3sO+IOl4cLulU3vF5nxPv5z9EjAdf7kGOnqf4=";
                 };
             unpackPhase = "tar -xzf $src";
             installPhase = ''


### PR DESCRIPTION
Bumps the Slack CLI from 3.12.0 to 4.0.1 across all flake.nix files. :hamsa:

The 4.0.1 release fixes prompt sequence ordering in `slack create agent`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)