### PR TITLE
js.bolt.surge(refactor): authorize vercel receiver oauth installation

### DIFF
--- a/js.bolt.surge/CHANGELOG.md
+++ b/js.bolt.surge/CHANGELOG.md
@@ -7,6 +7,7 @@ versioned with [calendar versioning][calver].
 
 ## Changes
 
+- refactor: authorize vercel receiver oauth installation 2026-04-25
 - build: set manifest schema a version for editor checks 2026-03-09
 - feat: collect feedback after email deliveries arriving 2026-03-04
 - docs: add development icon for testing in multiple app 2026-02-23

--- a/js.bolt.surge/server/api/slack/install.get.js
+++ b/js.bolt.surge/server/api/slack/install.get.js
@@ -1,4 +1,4 @@
-import { installer } from "../../app.js";
+import { receiver } from "../../app.js";
 
 /**
  * Redirect to Slack OAuth authorization page.
@@ -9,6 +9,8 @@ export default defineEventHandler(async (event) => {
 
   /** @type {string | undefined} */
   let redirectUrl;
+
+  const installer = /** @type {any} */ (receiver).installer;
 
   await installer.handleInstallPath(
     /** @type {import("http").IncomingMessage} */ ({

--- a/js.bolt.surge/server/api/slack/oauth_redirect.get.js
+++ b/js.bolt.surge/server/api/slack/oauth_redirect.get.js
@@ -1,73 +1,10 @@
-import { app, installer } from "../../app.js";
+import { receiver } from "../../app.js";
 
 /**
  * Handle OAuth callback from Slack.
  * @param {import("h3").H3Event} event
  */
 export default defineEventHandler(async (event) => {
-  const query = getQuery(event);
-  const code = /** @type {string} */ (query.code);
-  const state = /** @type {string} */ (query.state);
-
-  if (!code || !state) {
-    return sendRedirect(event, "/?error=missing_code_or_state");
-  }
-
-  /** @type {import("@slack/oauth").Installation | import("@slack/oauth").OrgInstallation | null} */
-  let installation = null;
-
-  /** @type {Error | null} */
-  let callbackError = null;
-
-  try {
-    await installer.handleCallback(
-      /** @type {import("http").IncomingMessage} */ ({
-        url: getRequestURL(event).toString(),
-        headers: getHeaders(event),
-      }),
-      /** @type {import("http").ServerResponse} */ (
-        /** @type {unknown} */ ({
-          setHeader: (
-            /** @type {string} */ name,
-            /** @type {string} */ value,
-          ) => setResponseHeader(event, name, value),
-          getHeader: (/** @type {string} */ name) =>
-            getResponseHeader(event, name),
-          writeHead: () => {},
-          end: () => {},
-        })
-      ),
-      {
-        successAsync: async (inst) => {
-          installation = inst;
-        },
-        failureAsync: async (err) => {
-          callbackError = err;
-        },
-      },
-    );
-
-    if (callbackError) {
-      throw callbackError;
-    }
-
-    const teamId = /** @type {import("@slack/oauth").Installation | null} */ (
-      installation
-    )?.team?.id;
-    const appId = /** @type {import("@slack/oauth").Installation | null} */ (
-      installation
-    )?.appId;
-
-    if (teamId && appId) {
-      const deeplink = encodeURIComponent(
-        `slack://app?team=${teamId}&id=${appId}&tab=home`,
-      );
-      return sendRedirect(event, `/?success=true&redirect=${deeplink}`);
-    }
-    return sendRedirect(event, "/?success=true");
-  } catch (err) {
-    const error = /** @type {Error} */ (err);
-    app.logger.error("OAuth callback failed", { error: error.message });
-    return sendRedirect(event, `/?error=${encodeURIComponent(error.message)}`);
-  }
+  const request = toWebRequest(event);
+  return /** @type {any} */ (receiver).handleCallback(request);
 });

--- a/js.bolt.surge/server/app.js
+++ b/js.bolt.surge/server/app.js
@@ -1,5 +1,4 @@
 import boltPkg from "@slack/bolt";
-import oauthPkg from "@slack/oauth";
 import { VercelReceiver } from "@vercel/slack-bolt";
 import { generateText } from "ai";
 import { db } from "./lib/database/index.js";
@@ -8,7 +7,6 @@ import { DatabaseStateStore } from "./lib/oauth/state-store.js";
 import { registerListeners } from "./listeners/index.js";
 
 const { App, LogLevel, SocketModeReceiver } = boltPkg;
-const { InstallProvider } = oauthPkg;
 
 const isProduction = process.env.SLACK_ENVIRONMENT_TAG === "production";
 const isVercel = Boolean(process.env.VERCEL);
@@ -16,6 +14,8 @@ const defaultLogLevel = isProduction ? LogLevel.INFO : LogLevel.DEBUG;
 const logLevel =
   /** @type {boltPkg.LogLevel | undefined} */ (process.env.LOG_LEVEL) ||
   defaultLogLevel;
+
+const installProvider = createInstallProvider(db);
 
 /**
  * Receiver for handling Slack events.
@@ -25,27 +25,39 @@ const logLevel =
 export const receiver = isVercel
   ? new VercelReceiver({
       logLevel,
+      installationStore: installProvider.installationStore,
+      installerOptions: {
+        stateStore: new DatabaseStateStore(),
+        directInstall: true,
+        callbackOptions: {
+          successAsync: async (installation, _installOptions, _req, res) => {
+            const teamId = installation.team?.id;
+            const appId = installation.appId;
+            if (teamId && appId) {
+              const deeplink = encodeURIComponent(
+                `slack://app?team=${teamId}&id=${appId}&tab=home`,
+              );
+              res.writeHead(302, {
+                Location: `/?success=true&redirect=${deeplink}`,
+              });
+            } else {
+              res.writeHead(302, { Location: "/?success=true" });
+            }
+            res.end();
+          },
+          failureAsync: async (error, _installOptions, _req, res) => {
+            res.writeHead(302, {
+              Location: `/?error=${encodeURIComponent(error.message)}`,
+            });
+            res.end();
+          },
+        },
+      },
     })
   : new SocketModeReceiver({
       appToken: /** @type {string} */ (process.env.SLACK_APP_TOKEN),
       logLevel,
     });
-
-/**
- * OAuth install provider for multi-workspace support.
- */
-const installProvider = createInstallProvider(db);
-
-/**
- * Shared OAuth installer for install/callback handlers.
- */
-export const installer = new InstallProvider({
-  clientId: /** @type {string} */ (process.env.SLACK_CLIENT_ID),
-  clientSecret: /** @type {string} */ (process.env.SLACK_CLIENT_SECRET),
-  stateStore: new DatabaseStateStore(),
-  installationStore: installProvider.installationStore,
-  directInstall: true,
-});
 
 /**
  * The Bolt Slack application.
@@ -56,21 +68,6 @@ export const installer = new InstallProvider({
 export const app = new App(
   isVercel
     ? {
-        authorize: async ({ teamId, enterpriseId, isEnterpriseInstall }) => {
-          const installation =
-            await installProvider.installationStore.fetchInstallation({
-              teamId,
-              enterpriseId,
-              isEnterpriseInstall: isEnterpriseInstall ?? false,
-            });
-          return {
-            botToken: installation.bot?.token,
-            botId: installation.bot?.id,
-            botUserId: installation.bot?.userId,
-            teamId: installation.team?.id,
-            enterpriseId: installation.enterprise?.id,
-          };
-        },
         signingSecret: process.env.SLACK_SIGNING_SECRET,
         receiver,
         deferInitialization: true,


### PR DESCRIPTION
Moves the OAuth token lookup out of a custom `authorize` function and into the installation store, letting `@vercel/slack-bolt` handle authorization through its built-in `InstallProvider`.

`VercelReceiver` 1.4.0 began auto-creating an `InstallProvider` from env vars (`SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_STATE_SECRET`). Bolt then detected both the explicit `authorize` and `receiver.installer.authorize` and threw `AppInitializationError: You cannot provide both authorize and oauth installer options` on every request.

The fix passes the database-backed `installationStore` and `DatabaseStateStore` directly to `VercelReceiver`, removes the redundant `authorize` function from the app, and simplifies the install and callback routes to use the receiver's installer.

:hamsa: