### PR TITLE
chore(ci): route slack actions through local proxy

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -27,7 +27,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Send a notification of completion
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: chat.postMessage
           proxy: "http://127.0.0.1:3128"
@@ -40,7 +40,7 @@ jobs:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
       - name: Send a notification of pending
         if: steps.metadata.outputs.update-type != 'version-update:semver-patch' && steps.metadata.outputs.update-type != 'version-update:semver-minor'
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: chat.postMessage
           proxy: "http://127.0.0.1:3128"
@@ -50,7 +50,7 @@ jobs:
             text: "${{ steps.metadata.outputs.directory }}(chore): dependencies have a pending update"
       - name: Send a notification of failure
         if: failure()
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: chat.postMessage
           proxy: "http://127.0.0.1:3128"
@@ -112,7 +112,7 @@ jobs:
           GH_TOKEN: ${{ secrets.SANDBOX_ACCESS_TOKEN }}
       - name: Message the happened errors
         if: failure()
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: chat.postMessage
           proxy: "http://127.0.0.1:3128"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,6 +30,7 @@ jobs:
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
           token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
@@ -42,6 +43,7 @@ jobs:
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
           token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
@@ -51,6 +53,7 @@ jobs:
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
           token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
@@ -112,6 +115,7 @@ jobs:
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
           token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}

--- a/.github/workflows/message.yml
+++ b/.github/workflows/message.yml
@@ -15,6 +15,7 @@ jobs:
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
           token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
@@ -24,6 +25,7 @@ jobs:
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: reactions.add
+          proxy: "http://127.0.0.1:3128"
           token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}

--- a/.github/workflows/message.yml
+++ b/.github/workflows/message.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Send a message to channel
         id: message
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: chat.postMessage
           proxy: "http://127.0.0.1:3128"
@@ -22,7 +22,7 @@ jobs:
             text: "chore(<!channel>): merge w the latest changes on main"
       - name: Respond with affection
         if: ${{ steps.message.outputs.ok }}
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: reactions.add
           proxy: "http://127.0.0.1:3128"

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -142,3 +142,6 @@ jobs:
           SLACK_APP_ID: ${{ vars.SLACK_APP_ID }}
           SLACK_CLI_TOKEN: ${{ secrets.SLACK_CLI_TOKEN }}
           SLACK_ENVIRONMENT_TAG: ${{ vars.SLACK_ENVIRONMENT_TAG }}
+      - name: Print an eye in speech bubble
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo ':eye-in-speech-bubble:'

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -132,6 +132,7 @@ jobs:
         run: |
           nix develop --command bash -c "${{ matrix.build }}"
       - name: Send a notification through the proxy
+        id: proxied
         uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: chat.postMessage
@@ -141,6 +142,7 @@ jobs:
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
             text: "${{ matrix.app }}(chore): checking the proxied release candidate"
       - name: Surface a web api error through the proxy
+        id: errored
         continue-on-error: true
         uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
@@ -151,6 +153,22 @@ jobs:
           payload: |
             channel: nonexistent-channel-xyz
             text: "${{ matrix.app }}(chore): this send should fail with channel_not_found"
+      - name: Echo the release candidate outputs
+        env:
+          PROXIED_RESPONSE: ${{ steps.proxied.outputs.response }}
+          ERRORED_RESPONSE: ${{ steps.errored.outputs.response }}
+        run: |
+          echo "--- success path (proxied) ---"
+          echo "ok=${{ steps.proxied.outputs.ok }}"
+          echo "time=${{ steps.proxied.outputs.time }}"
+          echo "channel_id=${{ steps.proxied.outputs.channel_id }}"
+          echo "thread_ts=${{ steps.proxied.outputs.thread_ts }}"
+          echo "ts=${{ steps.proxied.outputs.ts }}"
+          echo "response=$PROXIED_RESPONSE"
+          echo "--- error path (errored) ---"
+          echo "ok=${{ steps.errored.outputs.ok }}"
+          echo "time=${{ steps.errored.outputs.time }}"
+          echo "response=$ERRORED_RESPONSE"
       - name: Test ${{ matrix.app }}
         if: ${{ matrix.test }}
         run: |

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -65,6 +65,7 @@ jobs:
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
           token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -62,7 +62,7 @@ jobs:
           git commit -m "chore(sync): update sample with the latest upstream changes"
           git push -u origin ${{ matrix.branch }} --force
       - name: Send a notification of completion
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: chat.postMessage
           proxy: "http://127.0.0.1:3128"
@@ -151,7 +151,7 @@ jobs:
       contents: read
     steps:
       - name: Send a message to channel
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
         with:
           method: chat.postMessage
           proxy: "http://127.0.0.1:3128"

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -131,6 +131,15 @@ jobs:
         if: ${{ matrix.build }}
         run: |
           nix develop --command bash -c "${{ matrix.build }}"
+      - name: Send a notification through the proxy
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
+        with:
+          method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
+          token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
+            text: "${{ matrix.app }}(chore): checking the proxied release candidate"
       - name: Test ${{ matrix.app }}
         if: ${{ matrix.test }}
         run: |

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -142,6 +142,20 @@ jobs:
           SLACK_APP_ID: ${{ vars.SLACK_APP_ID }}
           SLACK_CLI_TOKEN: ${{ secrets.SLACK_CLI_TOKEN }}
           SLACK_ENVIRONMENT_TAG: ${{ vars.SLACK_ENVIRONMENT_TAG }}
-      - name: Print an eye in speech bubble
-        if: ${{ github.event_name == 'pull_request' }}
-        run: echo ':eye-in-speech-bubble:'
+  announce:
+    name: Announce pull requests
+    needs: publish
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: self-hosted
+    permissions:
+      contents: read
+    steps:
+      - name: Send a message to channel
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
+          token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
+            text: ":eye-in-speech-bubble:"

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -140,6 +140,17 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_GITHUB_ACTION_CHANNEL_ID }}
             text: "${{ matrix.app }}(chore): checking the proxied release candidate"
+      - name: Surface a web api error through the proxy
+        continue-on-error: true
+        uses: zimeg/slack-github-action@v3.0.6-rc.1
+        with:
+          errors: true
+          method: chat.postMessage
+          proxy: "http://127.0.0.1:3128"
+          token: ${{ secrets.SLACK_GITHUB_ACTION_BOT_TOKEN }}
+          payload: |
+            channel: nonexistent-channel-xyz
+            text: "${{ matrix.app }}(chore): this send should fail with channel_not_found"
       - name: Test ${{ matrix.app }}
         if: ${{ matrix.test }}
         run: |


### PR DESCRIPTION
## Summary
- route Slack GitHub Action requests through the local forward proxy on tom
- apply the proxy setting consistently across message, dependency, and sample notification workflows
- keep the workflow change isolated from the unrelated untracked repo content

## Notes
- this depends on the staged .DOTFILES change that enables a localhost-only tinyproxy listener on tom at http://127.0.0.1:3128
