### PR TITLE
actions(chore): skip node 26 updates in js.bolt.tails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,7 +77,9 @@ updates:
     directory: "js.bolt.tails"
     ignore:
       - dependency-name: "@types/node"
-        versions: ["25.x"]
+        versions:
+          - "25.x"
+          - "26.x"
     schedule:
       cronjob: 4 2 * * *
       interval: cron


### PR DESCRIPTION
Ignore `@types/node` 26.x for js.bolt.tails until the latest is active, alongside the existing 25.x hold. Reformats the version hold as a newline YAML array.

:hamsa: